### PR TITLE
onDismiss optional closure for Sheets & FullScreenCovers

### DIFF
--- a/Sources/Presenting/Models/Presenter.swift
+++ b/Sources/Presenting/Models/Presenter.swift
@@ -11,6 +11,7 @@ public typealias Presentable = SheetManageable & FullScreenCoverManageable & Ale
 public final class Presenter<Routes: ViewDisplayable>: Presentable {
     public typealias Destination = Routes
 
+    public var onDismiss: (() -> Void)?
     @Published public var sheet: Destination?
     @Published public var fullScreenCover: Destination?
     @Published public var alert: Alert?

--- a/Sources/Presenting/Protocols/FullScreenCoverManageable.swift
+++ b/Sources/Presenting/Protocols/FullScreenCoverManageable.swift
@@ -11,8 +11,8 @@ public protocol FullScreenCoverManageable: ObservableObject {
     associatedtype Destination: ViewDisplayable
 
     var fullScreenCover: Destination? { get set }
-
-    func presentFullScreenCover(_ destination: Destination)
+    var onDismiss: (() -> Void)? { get set }
+    func presentFullScreenCover(_ destination: Destination, onDismiss: @escaping () -> Void)
     func dismissFullScreenCover()
 }
 
@@ -20,8 +20,10 @@ extension FullScreenCoverManageable {
     
     /// Presents a full screen cover with the specified destination
     /// - Parameter destination: The destination to present as a full screen cover
-    public func presentFullScreenCover(_ destination: Destination) {
+    /// - Parameter onDismiss: The action to be triggered after the view is dismissed
+    public func presentFullScreenCover(_ destination: Destination, onDismiss: @escaping () -> Void = { }) {
         fullScreenCover = destination
+        self.onDismiss = onDismiss
     }
 
     /// Dismisses the currently presented full screen cover

--- a/Sources/Presenting/Protocols/SheetManageable.swift
+++ b/Sources/Presenting/Protocols/SheetManageable.swift
@@ -11,16 +11,18 @@ public protocol SheetManageable: ObservableObject {
     associatedtype Destination: ViewDisplayable
 
     var sheet: Destination? { get set }
-
-    func presentSheet(_ destination: Destination)
+    var onDismiss: (() -> Void)? { get set }
+    func presentSheet(_ destination: Destination, onDismiss: @escaping () -> Void)
     func dismissSheet()
 }
 
 extension SheetManageable {
     /// Presents a new sheet view
     /// - Parameter destination: The view to be presented as a sheet
-    public func presentSheet(_ destination: Destination) {
+    /// - Parameter onDismiss: The action to be triggered after the view is dismissed
+    public func presentSheet(_ destination: Destination, onDismiss: @escaping () -> Void = { }) {
         sheet = destination
+        self.onDismiss = onDismiss
     }
 
     /// Dismisses the currently presented sheet view

--- a/Sources/Presenting/Views/PresentingView.swift
+++ b/Sources/Presenting/Views/PresentingView.swift
@@ -17,6 +17,8 @@ public struct PresentingView<RootView: View, Routes: ViewDisplayable>: View {
     public var body: some View {
         rootView(presenter)
             .sheet(item: $presenter.sheet) {
+                presenter.onDismiss?()
+            } content: {
                 $0.viewToDisplay
                     .environmentObject(presenter)
             }

--- a/Sources/Presenting/Views/PresentingView.swift
+++ b/Sources/Presenting/Views/PresentingView.swift
@@ -32,10 +32,12 @@ public struct PresentingView<RootView: View, Routes: ViewDisplayable>: View {
                                onCompletion: presenter.dismissToast)
             }
 #if !os(macOS)
-            .fullScreenCover(item: $presenter.fullScreenCover) {
+            .fullScreenCover(item: $presenter.fullScreenCover, onDismiss: {
+                presenter.onDismiss?()
+            }, content: {
                 $0.viewToDisplay
                     .environmentObject(presenter)
-            }
+            })
 #endif
     }
 }

--- a/Tests/PresentingTests/FullScreenCoverManageableTests.swift
+++ b/Tests/PresentingTests/FullScreenCoverManageableTests.swift
@@ -32,6 +32,15 @@ final class FullScreenCoverManageableTests: XCTestCase {
         presenter.dismissFullScreenCover()
         XCTAssertNil(presenter.fullScreenCover)
     }
+    
+    func testOnDismiss() {
+        var didCallOnDismiss = false
+        presenter.presentFullScreenCover(.settings) {
+            didCallOnDismiss = true
+        }
+        presenter.onDismiss?()
+        XCTAssertTrue(didCallOnDismiss)
+    }
 }
 
 fileprivate class MockFullScreenCoverManager: FullScreenCoverManageable {

--- a/Tests/PresentingTests/SheetManageableTests.swift
+++ b/Tests/PresentingTests/SheetManageableTests.swift
@@ -32,6 +32,15 @@ final class SheetManageableTests: XCTestCase {
         presenter.dismissSheet()
         XCTAssertNil(presenter.sheet)
     }
+    
+    func testOnDismiss() {
+        var didCallOnDismiss = false
+        presenter.presentSheet(.settings) {
+            didCallOnDismiss = true
+        }
+        presenter.onDismiss?()
+        XCTAssertTrue(didCallOnDismiss)
+    }
 }
 
 fileprivate class MockSheetManager: SheetManageable {


### PR DESCRIPTION
**Description**

This pull request adds onDismiss support for Sheets & FullScreenCovers 

The onDismiss closure will get triggered after the Sheet is dismissed.

Example usage:

```swift
presenter.presentSheet(.settings, onDismiss: {
    print("Sheet dismissed!")
})

presenter.presentSheet(.settings) {
    print("Sheet dismissed!")
}

presenter.presentFullScreenCover(.settings, onDismiss: {
    print("FullScreenCover dismissed!")
})

presenter.presentFullScreenCover(.settings) {
    print("FullScreenCover dismissed!")
}
```