### PR TITLE
Add Open URL, Web, or Safari Link functions

### DIFF
--- a/Sources/Presenting/Models/Presenter.swift
+++ b/Sources/Presenting/Models/Presenter.swift
@@ -6,9 +6,10 @@
 
 import SwiftUI
 
-public typealias PresentableObject = SheetManageable & FullScreenCoverManageable & AlertManageable & ToastManageable
+public typealias PresentableObject = SheetManageable & FullScreenCoverManageable & AlertManageable & ToastManageable & URLManageable
 
 public final class Presenter<Routes: Presentable>: PresentableObject {
+    
     public typealias Destination = Routes
 
     public var onDismiss: (() -> Void)?
@@ -16,4 +17,5 @@ public final class Presenter<Routes: Presentable>: PresentableObject {
     @Published public var fullScreenCover: Destination?
     @Published public var alert: Alert?
     @Published public var toastConfig: ToastConfiguration?
+    @Published public var urlConfig: URLConfiguration?
 }

--- a/Sources/Presenting/URL/BrowserView.swift
+++ b/Sources/Presenting/URL/BrowserView.swift
@@ -1,5 +1,5 @@
 //
-//  SafariView.swift
+//  BrowserView.swift
 //
 //  Created by Ibrahim Hamed on 13/01/2024.
 //
@@ -12,12 +12,12 @@ import SwiftUI
 
 
 
-struct SafariView {
+struct BrowserView {
     let url: URL
 }
 
 #if !os(macOS)
-extension SafariView: UIViewControllerRepresentable {
+extension BrowserView: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> SFSafariViewController {
         return SFSafariViewController(url: url)
@@ -27,7 +27,7 @@ extension SafariView: UIViewControllerRepresentable {
 }
 
 #elseif os(macOS)
-extension SafariView: NSViewRepresentable {
+extension BrowserView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> WKWebView {
         return WKWebView()

--- a/Sources/Presenting/URL/SafariView.swift
+++ b/Sources/Presenting/URL/SafariView.swift
@@ -1,0 +1,18 @@
+//
+//  SafariView.swift
+//
+//  Created by Ibrahim Hamed on 13/01/2024.
+//
+
+import SafariServices
+import SwiftUI
+
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        return SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
+}

--- a/Sources/Presenting/URL/SafariView.swift
+++ b/Sources/Presenting/URL/SafariView.swift
@@ -3,12 +3,21 @@
 //
 //  Created by Ibrahim Hamed on 13/01/2024.
 //
-
+#if !os(macOS)
 import SafariServices
+#elseif os(macOS)
+import WebKit
+#endif
 import SwiftUI
 
-struct SafariView: UIViewControllerRepresentable {
+
+
+struct SafariView {
     let url: URL
+}
+
+#if !os(macOS)
+extension SafariView: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> SFSafariViewController {
         return SFSafariViewController(url: url)
@@ -16,3 +25,18 @@ struct SafariView: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
 }
+
+#elseif os(macOS)
+extension SafariView: NSViewRepresentable {
+
+    func makeNSView(context: Context) -> WKWebView {
+        return WKWebView()
+    }
+
+    func updateNSView(_ nsView: WKWebView, context: Context) {
+        let request = URLRequest(url: url)
+        nsView.load(request)
+    }
+}
+#endif
+

--- a/Sources/Presenting/URL/URLConfiguration.swift
+++ b/Sources/Presenting/URL/URLConfiguration.swift
@@ -1,0 +1,12 @@
+//
+//  URLConfiguration.swift
+//
+//  Created by Ibrahim Hamed on 13/01/2024.
+//
+
+import Foundation
+
+public struct URLConfiguration {
+    let urlOpeningType: URLOpeningType
+    let urlString: String
+}

--- a/Sources/Presenting/URL/URLConfiguration.swift
+++ b/Sources/Presenting/URL/URLConfiguration.swift
@@ -7,6 +7,6 @@
 import Foundation
 
 public struct URLConfiguration {
-    let urlOpeningType: URLOpeningType
-    let urlString: String
+    let type: URLOpeningType
+    let url: URL
 }

--- a/Sources/Presenting/URL/URLManageable.swift
+++ b/Sources/Presenting/URL/URLManageable.swift
@@ -1,0 +1,41 @@
+//
+//  URLManageable.swift
+//
+//  Created by Ibrahim Hamed on 13/01/2024.
+//
+
+import Foundation
+
+/// Protocol defining the requirements for an object to manage URL operations.
+public protocol URLManageable: ObservableObject {
+    /// Configuration for handling URLs. Stores details about how URLs should be opened.
+    var urlConfig: URLConfiguration? { get set }
+
+    /// Opens a URL based on a specified method.
+    ///
+    /// - Parameters:
+    ///   - type: The method for opening the URL (`UrlOpeningType`).
+    ///   - urlString: The URL string to be opened.
+    func open(_ type: URLOpeningType, urlString: String)
+
+    /// Clears the current URL configuration.
+    func clearURLConfig()
+}
+
+public extension URLManageable {
+    /// Opens a URL with a given opening type and URL string.
+    /// Sets up the URL configuration (`urlConfig`) for later use.
+    ///
+    /// - Parameters:
+    ///   - urlOpeningType: The method for opening the URL (`UrlOpeningType`).
+    ///   - urlString: The URL string to be opened.
+    func open(_ urlOpeningType: URLOpeningType, urlString: String) {
+        urlConfig = .init(urlOpeningType: urlOpeningType, urlString: urlString)
+    }
+
+    /// Clears the current URL configuration (`urlConfig`).
+    /// This function is useful for resetting or removing the URL configuration.
+    func clearURLConfig() {
+        urlConfig = nil
+    }
+}

--- a/Sources/Presenting/URL/URLManageable.swift
+++ b/Sources/Presenting/URL/URLManageable.swift
@@ -4,7 +4,11 @@
 //  Created by Ibrahim Hamed on 13/01/2024.
 //
 
+#if !os(macOS)
 import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 /// Protocol defining the requirements for an object to manage URL operations.
 public protocol URLManageable: ObservableObject {
@@ -31,10 +35,16 @@ public extension URLManageable {
     ///
     /// - Throws: Error if the URL is invalid
     func open(_ urlOpeningType: URLOpeningType, urlString: String) throws {
+#if !os(macOS)
         guard let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) else {
             throw URLOpeningError.invalidURL("The URL provided is not valid.")
         }
-        
+#elseif os(macOS)
+        guard let url = URL(string: urlString), NSWorkspace.shared.open(url) else {
+            throw URLOpeningError.invalidURL("The URL provided is not valid.")
+        }
+#endif
+
         urlConfig = .init(type: urlOpeningType, url: url)
     }
 }

--- a/Sources/Presenting/URL/URLManageable.swift
+++ b/Sources/Presenting/URL/URLManageable.swift
@@ -4,7 +4,7 @@
 //  Created by Ibrahim Hamed on 13/01/2024.
 //
 
-import Foundation
+import UIKit
 
 /// Protocol defining the requirements for an object to manage URL operations.
 public protocol URLManageable: ObservableObject {
@@ -16,10 +16,9 @@ public protocol URLManageable: ObservableObject {
     /// - Parameters:
     ///   - type: The method for opening the URL (`UrlOpeningType`).
     ///   - urlString: The URL string to be opened.
-    func open(_ type: URLOpeningType, urlString: String)
-
-    /// Clears the current URL configuration.
-    func clearURLConfig()
+    ///
+    /// - Throws: Error if the URL is invalid
+    func open(_ type: URLOpeningType, urlString: String) throws
 }
 
 public extension URLManageable {
@@ -29,13 +28,13 @@ public extension URLManageable {
     /// - Parameters:
     ///   - urlOpeningType: The method for opening the URL (`UrlOpeningType`).
     ///   - urlString: The URL string to be opened.
-    func open(_ urlOpeningType: URLOpeningType, urlString: String) {
-        urlConfig = .init(urlOpeningType: urlOpeningType, urlString: urlString)
-    }
-
-    /// Clears the current URL configuration (`urlConfig`).
-    /// This function is useful for resetting or removing the URL configuration.
-    func clearURLConfig() {
-        urlConfig = nil
+    ///
+    /// - Throws: Error if the URL is invalid
+    func open(_ urlOpeningType: URLOpeningType, urlString: String) throws {
+        guard let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) else {
+            throw URLOpeningError.invalidURL("The URL provided is not valid.")
+        }
+        
+        urlConfig = .init(type: urlOpeningType, url: url)
     }
 }

--- a/Sources/Presenting/URL/URLManageable.swift
+++ b/Sources/Presenting/URL/URLManageable.swift
@@ -15,26 +15,26 @@ public protocol URLManageable: ObservableObject {
     /// Configuration for handling URLs. Stores details about how URLs should be opened.
     var urlConfig: URLConfiguration? { get set }
 
-    /// Opens a URL based on a specified method.
+    /// Attempts to open a URL based on a specified `URLOpeningType` and a string.
     ///
     /// - Parameters:
-    ///   - type: The method for opening the URL (`UrlOpeningType`).
-    ///   - urlString: The URL string to be opened.
+    ///   - type: The method for opening the URL.
+    ///   - using: The URL string to open.
     ///
-    /// - Throws: Error if the URL is invalid
-    func open(_ type: URLOpeningType, urlString: String) throws
+    /// - Throws: An error if the URL is invalid or cannot be opened as specified.
+    func openUrl(_ type: URLOpeningType, using urlString: String) throws
 }
 
 public extension URLManageable {
-    /// Opens a URL with a given opening type and URL string.
+    /// Attempts to open a URL based on a specified `URLOpeningType` and a string.
     /// Sets up the URL configuration (`urlConfig`) for later use.
     ///
     /// - Parameters:
-    ///   - urlOpeningType: The method for opening the URL (`UrlOpeningType`).
-    ///   - urlString: The URL string to be opened.
+    ///   - type: The method for opening the URL.
+    ///   - using: The URL string to open.
     ///
-    /// - Throws: Error if the URL is invalid
-    func open(_ urlOpeningType: URLOpeningType, urlString: String) throws {
+    /// - Throws: An error if the URL is invalid or cannot be opened as specified.
+    func openUrl(_ urlOpeningType: URLOpeningType, using urlString: String) throws {
 #if !os(macOS)
         guard let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) else {
             throw URLOpeningError.invalidURL("The URL provided is not valid.")

--- a/Sources/Presenting/URL/URLModifier.swift
+++ b/Sources/Presenting/URL/URLModifier.swift
@@ -29,14 +29,11 @@ struct URLModifier: ViewModifier {
             .onAppear {
                 if let url = config?.url, let type = config?.type  {
                     switch type {
-                    case .safari:
+                    case .inBrowser:
                         openURL(url)
                         resetURLConfig()
-                    case .inAppBrowser:
+                    case .inApp:
                         isInAppBrowserPresented = true
-                    case .urlSchema:
-                        openURLSchema(url)
-                        resetURLConfig()
                     }
                 }
             }
@@ -45,7 +42,7 @@ struct URLModifier: ViewModifier {
                 resetURLConfig()
             }, content: {
                 if let url = config?.url {
-                    SafariView(url: url)
+                    BrowserView(url: url)
                         .ignoresSafeArea(.all)
                 }
             })
@@ -53,13 +50,5 @@ struct URLModifier: ViewModifier {
 
     private func resetURLConfig() {
         config = nil
-    }
-    
-    private func openURLSchema(_ url: URL){
-#if !os(macOS)
-        UIApplication.shared.open(url)
-#elseif os(macOS)
-        NSWorkspace.shared.open(url)
-#endif
     }
 }

--- a/Sources/Presenting/URL/URLModifier.swift
+++ b/Sources/Presenting/URL/URLModifier.swift
@@ -35,7 +35,7 @@ struct URLModifier: ViewModifier {
                     case .inAppBrowser:
                         isInAppBrowserPresented = true
                     case .urlSchema:
-                        UIApplication.shared.open(url)
+                        openURLSchema(url)
                         resetURLConfig()
                     }
                 }
@@ -53,5 +53,13 @@ struct URLModifier: ViewModifier {
 
     private func resetURLConfig() {
         config = nil
+    }
+    
+    private func openURLSchema(_ url: URL){
+#if !os(macOS)
+        UIApplication.shared.open(url)
+#elseif os(macOS)
+        NSWorkspace.shared.open(url)
+#endif
     }
 }

--- a/Sources/Presenting/URL/URLModifier.swift
+++ b/Sources/Presenting/URL/URLModifier.swift
@@ -18,7 +18,7 @@ extension View {
 
 struct URLModifier: ViewModifier {
     @Environment(\.openURL) var openURL
-    @State private var isInAppSafariPresented: Bool = false
+    @State private var isInAppBrowserPresented: Bool = false
     private let config: URLConfiguration
     private let onCompletion: () -> Void
 
@@ -36,14 +36,14 @@ struct URLModifier: ViewModifier {
                         openURL(url)
                         clearURLConfig()
                     case .inAppBrowser:
-                        isInAppSafariPresented = true
+                        isInAppBrowserPresented = true
                     case .urlSchema:
                         UIApplication.shared.open(url)
                         clearURLConfig()
                     }
                 }
             }
-            .sheet(isPresented: $isInAppSafariPresented) {
+            .sheet(isPresented: $isInAppBrowserPresented) {
                 if let url = URL(string: config.urlString) {
                     SafariView(url: url)
                         .ignoresSafeArea(.all)

--- a/Sources/Presenting/URL/URLModifier.swift
+++ b/Sources/Presenting/URL/URLModifier.swift
@@ -1,0 +1,60 @@
+//
+//  URLModifier.swift
+//
+//  Created by Ibrahim Hamed on 13/01/2024.
+//
+
+import SwiftUI
+
+/// Extension to open url at any View
+/// - Parameters:
+///   - config: The configuration for the URL.
+///   - onCompletion: A closure that is called after the URL opening action is completed.
+extension View {
+    func openURL(config: URLConfiguration, onCompletion: @escaping () -> Void) -> some View {
+        modifier(URLModifier(config: config, onCompletion: onCompletion))
+    }
+}
+
+struct URLModifier: ViewModifier {
+    @Environment(\.openURL) var openURL
+    @State private var isInAppSafariPresented: Bool = false
+    private let config: URLConfiguration
+    private let onCompletion: () -> Void
+
+    init(config: URLConfiguration, onCompletion: @escaping () -> Void) {
+        self.config = config
+        self.onCompletion = onCompletion
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                if let url = URL(string: config.urlString) {
+                    switch config.urlOpeningType {
+                    case .safari:
+                        openURL(url)
+                        clearURLConfig()
+                    case .inAppBrowser:
+                        isInAppSafariPresented = true
+                    case .urlSchema:
+                        UIApplication.shared.open(url)
+                        clearURLConfig()
+                    }
+                }
+            }
+            .sheet(isPresented: $isInAppSafariPresented) {
+                if let url = URL(string: config.urlString) {
+                    SafariView(url: url)
+                        .ignoresSafeArea(.all)
+                        .onDisappear {
+                            clearURLConfig()
+                        }
+                }
+            }
+    }
+
+    private func clearURLConfig() {
+        onCompletion()
+    }
+}

--- a/Sources/Presenting/URL/URLOpeningError.swift
+++ b/Sources/Presenting/URL/URLOpeningError.swift
@@ -1,0 +1,13 @@
+//
+//  URLOpeningError.swift
+//
+//  Created by Ibrahim Hamed on 14/01/2024.
+//
+
+import Foundation
+
+/// `URLOpeningError` is an enum representing errors in URL processing.
+enum URLOpeningError: Error {
+    /// `invalidURL(String)`: Indicates an invalid URL with the erroneous URL string provided.
+    case invalidURL(String)
+}

--- a/Sources/Presenting/URL/URLOpeningType.swift
+++ b/Sources/Presenting/URL/URLOpeningType.swift
@@ -1,0 +1,13 @@
+//
+//  URLOpeningType.swift
+//
+//  Created by Ibrahim Hamed on 13/01/2024.
+//
+
+import Foundation
+
+public enum URLOpeningType {
+    case safari
+    case inAppBrowser
+    case urlSchema
+}

--- a/Sources/Presenting/URL/URLOpeningType.swift
+++ b/Sources/Presenting/URL/URLOpeningType.swift
@@ -6,8 +6,15 @@
 
 import Foundation
 
+/// Enumerates the types of URL opening methods in an application.
 public enum URLOpeningType {
+    /// `safari`: Opens the URL in the Safari browser. This method takes the user out of the app to the default web browser on the device.
     case safari
+
+    /// `inAppBrowser`: Opens the URL within the app using an in-app browser,.
     case inAppBrowser
+
+    /// `urlSchema`: Handles custom URL schemes. Used for deep linking into other apps or for specific in-app actions based on custom URL patterns.
     case urlSchema
 }
+

--- a/Sources/Presenting/URL/URLOpeningType.swift
+++ b/Sources/Presenting/URL/URLOpeningType.swift
@@ -6,15 +6,13 @@
 
 import Foundation
 
-/// Enumerates the types of URL opening methods in an application.
+/// Enumerates URL opening methods in an application.
 public enum URLOpeningType {
-    /// `safari`: Opens the URL in the Safari browser. This method takes the user out of the app to the default web browser on the device.
-    case safari
+    /// `inBrowser`: Opens URLs in the device's default web browser.
+    case inBrowser
 
-    /// `inAppBrowser`: Opens the URL within the app using an in-app browser,.
-    case inAppBrowser
-
-    /// `urlSchema`: Handles custom URL schemes. Used for deep linking into other apps or for specific in-app actions based on custom URL patterns.
-    case urlSchema
+    /// `inApp`: Opens URLs within the app using an in-app browser or custom URL schemes.
+    case inApp
 }
+
 

--- a/Sources/Presenting/Views/PresentingView.swift
+++ b/Sources/Presenting/Views/PresentingView.swift
@@ -30,6 +30,9 @@ public struct PresentingView<RootView: View, Routes: Presentable>: View {
                 rootView.toast(config: toastConfig,
                                onCompletion: presenter.dismissToast)
             }
+            .iflet(presenter.urlConfig) { rootView, urlConfig in
+                rootView.openURL(config: urlConfig,onCompletion: presenter.clearURLConfig)
+            }
 #if !os(macOS)
             .fullScreenCover(item: $presenter.fullScreenCover, onDismiss: {
                 presenter.onDismiss?()

--- a/Sources/Presenting/Views/PresentingView.swift
+++ b/Sources/Presenting/Views/PresentingView.swift
@@ -30,8 +30,8 @@ public struct PresentingView<RootView: View, Routes: Presentable>: View {
                 rootView.toast(config: toastConfig,
                                onCompletion: presenter.dismissToast)
             }
-            .iflet(presenter.urlConfig) { rootView, urlConfig in
-                rootView.openURL(config: urlConfig,onCompletion: presenter.clearURLConfig)
+            .iflet(presenter.urlConfig) { rootView, _ in
+                rootView.openURL(config: $presenter.urlConfig)
             }
 #if !os(macOS)
             .fullScreenCover(item: $presenter.fullScreenCover, onDismiss: {

--- a/Tests/PresentingTests/URLManageableTests.swift
+++ b/Tests/PresentingTests/URLManageableTests.swift
@@ -22,7 +22,7 @@ final class URLManageableTests: XCTestCase {
     
     func testOpenURLWithValidURL(){
         do {
-            try presenter.open(.inAppBrowser, urlString: "https://www.google.com")
+            try presenter.openUrl(.inApp, using: "https://www.google.com")
         } catch {
             XCTFail("Error occurred: \(error)")
         }
@@ -31,7 +31,7 @@ final class URLManageableTests: XCTestCase {
     
     func testOpenURLWithInvalidURL() {
         let urlString = "invalid_url"
-        XCTAssertThrowsError(try presenter.open(.safari, urlString: urlString))
+        XCTAssertThrowsError(try presenter.openUrl(.inBrowser, using: urlString))
     }
 }
 

--- a/Tests/PresentingTests/URLManageableTests.swift
+++ b/Tests/PresentingTests/URLManageableTests.swift
@@ -20,17 +20,19 @@ final class URLManageableTests: XCTestCase {
         super.tearDown()
     }
     
-    func testOpenURL(){
-        presenter.open(.inAppBrowser, urlString: "https://www.google.com")
+    func testOpenURLWithValidURL(){
+        do {
+            try presenter.open(.inAppBrowser, urlString: "https://www.google.com")
+        } catch {
+            XCTFail("Error occurred: \(error)")
+        }
         XCTAssertNotNil(presenter.urlConfig)
     }
     
-    func testClearURLConfig(){
-        presenter.open(.inAppBrowser, urlString: "https://www.google.com")
-        presenter.clearURLConfig()
-        XCTAssertNil(presenter.urlConfig)
+    func testOpenURLWithInvalidURL() {
+        let urlString = "invalid_url"
+        XCTAssertThrowsError(try presenter.open(.safari, urlString: urlString))
     }
-    
 }
 
 fileprivate class MockURLManager: URLManageable {

--- a/Tests/PresentingTests/URLManageableTests.swift
+++ b/Tests/PresentingTests/URLManageableTests.swift
@@ -1,0 +1,38 @@
+//
+//  URLManageableTests.swift
+//
+//  Created by Ibrahim Hamed on 13/01/2024.
+//
+
+import XCTest
+@testable import Presenting
+
+final class URLManageableTests: XCTestCase {
+    private var presenter: MockURLManager!
+    
+    override func setUp() {
+        super.setUp()
+        presenter = .init()
+    }
+
+    override func tearDown() {
+        presenter = nil
+        super.tearDown()
+    }
+    
+    func testOpenURL(){
+        presenter.open(.inAppBrowser, urlString: "https://www.google.com")
+        XCTAssertNotNil(presenter.urlConfig)
+    }
+    
+    func testClearURLConfig(){
+        presenter.open(.inAppBrowser, urlString: "https://www.google.com")
+        presenter.clearURLConfig()
+        XCTAssertNil(presenter.urlConfig)
+    }
+    
+}
+
+fileprivate class MockURLManager: URLManageable {
+    @Published var urlConfig: URLConfiguration?
+}


### PR DESCRIPTION
Hello James 👋,

This pull request addresses Issue #4: "Open URL, Web, or Safari Link." The update introduces new functionalities for the `URLManageable` protocol, enabling it to handle different types of URL presentations, including opening links in Safari, an in-app browser, and via URL schema.

I also documented  and wrote unit testing for `URLManageable`

I look forward to your feedback on this pull request.

Best regards,

Ibrahim Hamed
