### PR TITLE
Issue #1 - Add Support for Confirmation Dialogs 🔥

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Description
 
 `Presenting` is a **lightweight** SwiftUI library for abstracting logic from views.
-- Handle presenting sheets, fullScreenCover, alert, & toast.
+- Handle presenting sheets, fullScreenCover, alert, toast, and confirmation dialogs.
 - Unit Tested protocol implementations.
 - Zero 3rd party dependencies.
 
@@ -84,8 +84,8 @@ struct ContentView: View {
 }
 ```
 
-3. Handle presenting sheets, fullScreenCovers, alerts, & toasts
-by using the `Presenter` functions:
+3. Handle presenting sheets, fullScreenCovers, alerts, toasts,
+and confirmation dialogs by using the `Presenter` functions:
 
 ```swift
 // MARK: Sheet
@@ -124,10 +124,17 @@ func presentToast(on edge: VerticalEdge, _ toast: Toast, isAutoDismissed: Bool)
 
 /// Dismisses the currently presented toast notification.
 func dismissToast()
+
+// MARK: Confirmation Dialog
+/// Presents the specified confirmation dialog.
+public func presentConfirmationDialog(_ confirmationDialog: ConfirmationDialog)
+
+/// Dismisses the currently presented confirmation dialog.
+public func dismissConfirmationDialog()
 ```
 
 4. If you don't need to present views in a sheet or full screen cover, use the `BasicPresentingView` instead.
-This will allow you to present alerts & toasts over a view.
+This will allow you to present alerts, toasts, and confirmation dialogs over a view.
 
 ``` swift
 import SwiftUI

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
@@ -7,15 +7,90 @@
 
 import SwiftUI
 
-public struct ConfirmationDialog<A: View> {
+public struct ConfirmationDialog {
     let title: Text
-    let titleVisilibity: Visibility
-    let actions: A
+    let titleVisibility: Visibility
+    var actions: AnyView
 
     // confirmationDialog(_:isPresented:titleVisibility:actions:)
-    init(_ title: Text, titleVisibility: Visibility = .automatic, @ViewBuilder actions: () -> A) {
+    init(_ title: Text, titleVisibility: Visibility = .automatic, @ViewBuilder actions: @escaping () -> AnyView) {
         self.title = title
-        self.titleVisilibity = titleVisibility
+        self.titleVisibility = titleVisibility
         self.actions = actions()
+    }
+}
+
+/// Protocol defining the requirements for an object to manage confirmation dialogs.
+public protocol ConfirmationDialogManageable: ObservableObject {
+    /// Configuration for the confirmation dialog.
+    var confirmationDialog: ConfirmationDialog? { get set }
+
+    /// A binding indicating whether a confirmation dialog is currently presented.
+    var isConfirmationDialogPresented: Binding<Bool> { get set }
+
+    /// Presents the specified confirmation dialog.
+    func presentConfirmationDialog(_ confirmationDialog: ConfirmationDialog)
+
+    /// Dismisses the currently presented confirmation dialog.
+    func dismissConfirmationDialog()
+}
+
+extension ConfirmationDialogManageable {
+    /// A computed property that returns a Binding<Bool> based on the presence of a confirmation dialog.
+    /// The getter returns true if a confirmation dialog is present, and false otherwise.
+    /// The setter sets the confirmation dialog to nil if the new value is false.
+    public var isConfirmationDialogPresented: Binding<Bool> {
+        get {
+            return Binding<Bool>(
+                get: { self.confirmationDialog != nil },
+                set: { newValue in
+                    if !newValue {
+                        self.confirmationDialog = nil
+                    }
+                }
+            )
+        }
+        set {
+            if !newValue.wrappedValue {
+                self.confirmationDialog = nil
+            }
+        }
+    }
+
+    /// Presents the specified confirmation dialog.
+    public func presentConfirmationDialog(_ confirmationDialog: ConfirmationDialog) {
+        self.confirmationDialog = confirmationDialog
+    }
+
+    /// Dismisses the currently presented confirmation dialog.
+    public func dismissConfirmationDialog() {
+        confirmationDialog = nil
+    }
+}
+
+extension View {
+    public func confirmationDialog(config: ConfirmationDialog, isPresented: Binding<Bool>) -> some View {
+        self.modifier(ConfirmationDialogModifier(config: config, isPresented: isPresented))
+    }
+}
+
+public struct ConfirmationDialogModifier: ViewModifier {
+    private var isPresented: Binding<Bool>
+    private let confirmationDialog: ConfirmationDialog
+
+    init(
+        config confirmationDialog: ConfirmationDialog,
+        isPresented: Binding<Bool>) {
+            self.confirmationDialog = confirmationDialog
+            self.isPresented = isPresented
+        }
+
+    public func body(content: Content) -> some View {
+        content
+            .confirmationDialog(
+                confirmationDialog.title,
+                isPresented: isPresented) {
+                    confirmationDialog.actions
+                }
     }
 }

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
@@ -33,13 +33,13 @@ public struct ConfirmationDialog {
     }
     
     // confirmationDialog(_:isPresented:titleVisibility:presenting:actions:message:)
-//    public init<T>(_ title: Text, titleVisibility: Visibility = .automatic,
-//                   presenting data: T?,
-//                   @ViewBuilder actions: @escaping (T) -> some View,
-//                   @ViewBuilder message: @escaping (T) -> some View) {
-//        self.title = title
-//        self.titleVisibility = titleVisibility
-//        self.actions = AnyView(actions(T.self as! T))
-//        self.message = AnyView(message(T.self as! T))
-//    }
+    public init<T>(_ title: Text, titleVisibility: Visibility = .automatic,
+                   presenting data: T?,
+                   @ViewBuilder actions: @escaping (T) -> some View,
+                   @ViewBuilder message: @escaping (T) -> some View) {
+        self.title = title
+        self.titleVisibility = titleVisibility
+        self.actions = AnyView(actions(T.self as! T))
+        self.message = AnyView(message(T.self as! T))
+    }
 }

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
@@ -13,7 +13,7 @@ public struct ConfirmationDialog {
     var actions: AnyView
 
     // confirmationDialog(_:isPresented:titleVisibility:actions:)
-    init(_ title: Text, titleVisibility: Visibility = .automatic, @ViewBuilder actions: @escaping () -> AnyView) {
+    public init(_ title: Text, titleVisibility: Visibility = .automatic, @ViewBuilder actions: @escaping () -> AnyView) {
         self.title = title
         self.titleVisibility = titleVisibility
         self.actions = actions()
@@ -69,7 +69,7 @@ extension ConfirmationDialogManageable {
 }
 
 extension View {
-    public func confirmationDialog(config: ConfirmationDialog, isPresented: Binding<Bool>) -> some View {
+    func confirmationDialog(config: ConfirmationDialog, isPresented: Binding<Bool>) -> some View {
         self.modifier(ConfirmationDialogModifier(config: config, isPresented: isPresented))
     }
 }

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
@@ -1,0 +1,21 @@
+//
+//  ConfirmationDialog.swift
+//
+//
+//  Created by Giorgio Latour on 1/13/24.
+//
+
+import SwiftUI
+
+public struct ConfirmationDialog<A: View> {
+    let title: Text
+    let titleVisilibity: Visibility
+    let actions: A
+
+    // confirmationDialog(_:isPresented:titleVisibility:actions:)
+    init(_ title: Text, titleVisibility: Visibility = .automatic, @ViewBuilder actions: () -> A) {
+        self.title = title
+        self.titleVisilibity = titleVisibility
+        self.actions = actions()
+    }
+}

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
@@ -31,7 +31,7 @@ public struct ConfirmationDialog {
         self.actions = AnyView(actions())
         self.message = AnyView(message())
     }
-    
+
     // confirmationDialog(_:isPresented:titleVisibility:presenting:actions:message:)
     public init<T>(_ title: Text, titleVisibility: Visibility = .automatic,
                    presenting data: T?,
@@ -39,7 +39,13 @@ public struct ConfirmationDialog {
                    @ViewBuilder message: @escaping (T) -> some View) {
         self.title = title
         self.titleVisibility = titleVisibility
-        self.actions = AnyView(actions(T.self as! T))
-        self.message = AnyView(message(T.self as! T))
+
+        if let data = data {
+            self.actions = AnyView(actions(data))
+            self.message = AnyView(message(data))
+        } else {
+            self.actions = AnyView(EmptyView())
+            self.message = AnyView(EmptyView())
+        }
     }
 }

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
@@ -10,87 +10,36 @@ import SwiftUI
 public struct ConfirmationDialog {
     let title: Text
     let titleVisibility: Visibility
-    var actions: AnyView
+    let actions: AnyView
+    let message: AnyView
 
     // confirmationDialog(_:isPresented:titleVisibility:actions:)
-    public init(_ title: Text, titleVisibility: Visibility = .automatic, @ViewBuilder actions: @escaping () -> some View) {
+    public init(_ title: Text, titleVisibility: Visibility = .automatic,
+                @ViewBuilder actions: @escaping () -> some View) {
         self.title = title
         self.titleVisibility = titleVisibility
         self.actions = AnyView(actions())
-    }
-}
-
-/// Protocol defining the requirements for an object to manage confirmation dialogs.
-public protocol ConfirmationDialogManageable: ObservableObject {
-    /// Configuration for the confirmation dialog.
-    var confirmationDialog: ConfirmationDialog? { get set }
-
-    /// A binding indicating whether a confirmation dialog is currently presented.
-    var isConfirmationDialogPresented: Binding<Bool> { get set }
-
-    /// Presents the specified confirmation dialog.
-    func presentConfirmationDialog(_ confirmationDialog: ConfirmationDialog)
-
-    /// Dismisses the currently presented confirmation dialog.
-    func dismissConfirmationDialog()
-}
-
-extension ConfirmationDialogManageable {
-    /// A computed property that returns a Binding<Bool> based on the presence of a confirmation dialog.
-    /// The getter returns true if a confirmation dialog is present, and false otherwise.
-    /// The setter sets the confirmation dialog to nil if the new value is false.
-    public var isConfirmationDialogPresented: Binding<Bool> {
-        get {
-            return Binding<Bool>(
-                get: { self.confirmationDialog != nil },
-                set: { newValue in
-                    if !newValue {
-                        self.confirmationDialog = nil
-                    }
-                }
-            )
-        }
-        set {
-            if !newValue.wrappedValue {
-                self.confirmationDialog = nil
-            }
-        }
+        self.message = AnyView(EmptyView())
     }
 
-    /// Presents the specified confirmation dialog.
-    public func presentConfirmationDialog(_ confirmationDialog: ConfirmationDialog) {
-        self.confirmationDialog = confirmationDialog
+    // confirmationDialog(_:isPresented:titleVisibility:actions:message:)
+    public init(_ title: Text, titleVisibility: Visibility = .automatic,
+                @ViewBuilder actions: @escaping () -> some View,
+                @ViewBuilder message: @escaping () -> some View) {
+        self.title = title
+        self.titleVisibility = titleVisibility
+        self.actions = AnyView(actions())
+        self.message = AnyView(message())
     }
-
-    /// Dismisses the currently presented confirmation dialog.
-    public func dismissConfirmationDialog() {
-        confirmationDialog = nil
-    }
-}
-
-extension View {
-    func confirmationDialog(config: ConfirmationDialog, isPresented: Binding<Bool>) -> some View {
-        self.modifier(ConfirmationDialogModifier(config: config, isPresented: isPresented))
-    }
-}
-
-public struct ConfirmationDialogModifier: ViewModifier {
-    private var isPresented: Binding<Bool>
-    private let confirmationDialog: ConfirmationDialog
-
-    init(
-        config confirmationDialog: ConfirmationDialog,
-        isPresented: Binding<Bool>) {
-            self.confirmationDialog = confirmationDialog
-            self.isPresented = isPresented
-        }
-
-    public func body(content: Content) -> some View {
-        content
-            .confirmationDialog(
-                confirmationDialog.title,
-                isPresented: isPresented) {
-                    confirmationDialog.actions
-                }
-    }
+    
+    // confirmationDialog(_:isPresented:titleVisibility:presenting:actions:message:)
+//    public init<T>(_ title: Text, titleVisibility: Visibility = .automatic,
+//                   presenting data: T?,
+//                   @ViewBuilder actions: @escaping (T) -> some View,
+//                   @ViewBuilder message: @escaping (T) -> some View) {
+//        self.title = title
+//        self.titleVisibility = titleVisibility
+//        self.actions = AnyView(actions(T.self as! T))
+//        self.message = AnyView(message(T.self as! T))
+//    }
 }

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
@@ -13,39 +13,59 @@ public struct ConfirmationDialog {
     let actions: AnyView
     let message: AnyView
 
-    // confirmationDialog(_:isPresented:titleVisibility:actions:)
+    ///  Creates a ConfirmationDialog object.
+    ///  - Parameters:
+    ///     - title: The title of the dialog.
+    ///     - titleVisibility: The visibility of the dialog's title.
+    ///     - actions: A view builder returning the dialog's actions.
     public init(_ title: Text, titleVisibility: Visibility = .automatic,
-                @ViewBuilder actions: @escaping () -> some View) {
+                @ViewBuilder actions: () -> some View) {
         self.title = title
         self.titleVisibility = titleVisibility
-        self.actions = AnyView(actions())
-        self.message = AnyView(EmptyView())
+        self.actions = actions().eraseToAnyView()
+        self.message = EmptyView().eraseToAnyView()
     }
 
-    // confirmationDialog(_:isPresented:titleVisibility:actions:message:)
+    ///  Creates a ConfirmationDialog object with a message.
+    ///  - Parameters:
+    ///     - title: The title of the dialog.
+    ///     - titleVisibility: The visibility of the dialog's title.
+    ///     - actions: A view builder returning the dialog's actions.
+    ///     - message: A view builder returning the message for the dialog.
     public init(_ title: Text, titleVisibility: Visibility = .automatic,
-                @ViewBuilder actions: @escaping () -> some View,
-                @ViewBuilder message: @escaping () -> some View) {
+                @ViewBuilder actions: () -> some View,
+                @ViewBuilder message: () -> some View) {
         self.title = title
         self.titleVisibility = titleVisibility
-        self.actions = AnyView(actions())
-        self.message = AnyView(message())
+        self.actions = actions().eraseToAnyView()
+        self.message = message().eraseToAnyView()
     }
 
-    // confirmationDialog(_:isPresented:titleVisibility:presenting:actions:message:)
+    ///  Creates a ConfirmationDialog object with a message using data to
+    ///  produce the dialog's content and a text view for the message.
+    ///  - Parameters:
+    ///     - title: The title of the dialog.
+    ///     - titleVisibility: The visibility of the dialog's title.
+    ///     - data: An optional source of truth for the confirmation dialog. The contents
+    ///     of data are passed to the actions and message closures. A nil value results
+    ///     in EmptyViews being passed to the two closures.
+    ///     - actions: A view builder returning the dialog's actions given the
+    ///     currently available data.
+    ///     - message: A view builder returning the message for the dialog
+    ///     given the currently available data.
     public init<T>(_ title: Text, titleVisibility: Visibility = .automatic,
                    presenting data: T?,
-                   @ViewBuilder actions: @escaping (T) -> some View,
-                   @ViewBuilder message: @escaping (T) -> some View) {
+                   @ViewBuilder actions: (T) -> some View,
+                   @ViewBuilder message: (T) -> some View) {
         self.title = title
         self.titleVisibility = titleVisibility
 
-        if let data = data {
-            self.actions = AnyView(actions(data))
-            self.message = AnyView(message(data))
+        if let data {
+            self.actions = actions(data).eraseToAnyView()
+            self.message = message(data).eraseToAnyView()
         } else {
-            self.actions = AnyView(EmptyView())
-            self.message = AnyView(EmptyView())
+            self.actions = EmptyView().eraseToAnyView()
+            self.message = EmptyView().eraseToAnyView()
         }
     }
 }

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialog.swift
@@ -13,10 +13,10 @@ public struct ConfirmationDialog {
     var actions: AnyView
 
     // confirmationDialog(_:isPresented:titleVisibility:actions:)
-    public init(_ title: Text, titleVisibility: Visibility = .automatic, @ViewBuilder actions: @escaping () -> AnyView) {
+    public init(_ title: Text, titleVisibility: Visibility = .automatic, @ViewBuilder actions: @escaping () -> some View) {
         self.title = title
         self.titleVisibility = titleVisibility
-        self.actions = actions()
+        self.actions = AnyView(actions())
     }
 }
 

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialogManageable.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialogManageable.swift
@@ -1,0 +1,56 @@
+//
+//  ConfirmationDialogManageable.swift
+//
+//
+//  Created by Giorgio Latour on 1/14/24.
+//
+
+import SwiftUI
+
+/// Protocol defining the requirements for an object to manage confirmation dialogs.
+public protocol ConfirmationDialogManageable: ObservableObject {
+    /// Configuration for the confirmation dialog.
+    var confirmationDialog: ConfirmationDialog? { get set }
+
+    /// A binding indicating whether a confirmation dialog is currently presented.
+    var isConfirmationDialogPresented: Binding<Bool> { get set }
+
+    /// Presents the specified confirmation dialog.
+    func presentConfirmationDialog(_ confirmationDialog: ConfirmationDialog)
+
+    /// Dismisses the currently presented confirmation dialog.
+    func dismissConfirmationDialog()
+}
+
+extension ConfirmationDialogManageable {
+    /// A computed property that returns a Binding<Bool> based on the presence of a confirmation dialog.
+    /// The getter returns true if a confirmation dialog is present, and false otherwise.
+    /// The setter sets the confirmation dialog to nil if the new value is false.
+    public var isConfirmationDialogPresented: Binding<Bool> {
+        get {
+            return Binding<Bool>(
+                get: { self.confirmationDialog != nil },
+                set: { newValue in
+                    if !newValue {
+                        self.confirmationDialog = nil
+                    }
+                }
+            )
+        }
+        set {
+            if !newValue.wrappedValue {
+                self.confirmationDialog = nil
+            }
+        }
+    }
+
+    /// Presents the specified confirmation dialog.
+    public func presentConfirmationDialog(_ confirmationDialog: ConfirmationDialog) {
+        self.confirmationDialog = confirmationDialog
+    }
+
+    /// Dismisses the currently presented confirmation dialog.
+    public func dismissConfirmationDialog() {
+        confirmationDialog = nil
+    }
+}

--- a/Sources/Presenting/ConfirmationDialog/ConfirmationDialogModifier.swift
+++ b/Sources/Presenting/ConfirmationDialog/ConfirmationDialogModifier.swift
@@ -1,0 +1,36 @@
+//
+//  ConfirmationDialogModifier.swift
+//
+//
+//  Created by Giorgio Latour on 1/14/24.
+//
+
+import SwiftUI
+
+extension View {
+    func confirmationDialog(config: ConfirmationDialog, isPresented: Binding<Bool>) -> some View {
+        self.modifier(ConfirmationDialogModifier(config: config, isPresented: isPresented))
+    }
+}
+
+public struct ConfirmationDialogModifier: ViewModifier {
+    private var isPresented: Binding<Bool>
+    private let confirmationDialog: ConfirmationDialog
+
+    init(
+        config confirmationDialog: ConfirmationDialog,
+        isPresented: Binding<Bool>) {
+            self.confirmationDialog = confirmationDialog
+            self.isPresented = isPresented
+        }
+
+    public func body(content: Content) -> some View {
+        content
+            .confirmationDialog(confirmationDialog.title, isPresented: isPresented,
+                                titleVisibility: confirmationDialog.titleVisibility) {
+                confirmationDialog.actions
+            } message: {
+                confirmationDialog.message
+            }
+    }
+}

--- a/Sources/Presenting/Models/BasicPresenter.swift
+++ b/Sources/Presenting/Models/BasicPresenter.swift
@@ -6,9 +6,10 @@
 
 import SwiftUI
 
-public typealias BasicPresentableObject = AlertManageable & ToastManageable
+public typealias BasicPresentableObject = AlertManageable & ToastManageable & ConfirmationDialogManageable
 
 public final class BasicPresenter: BasicPresentableObject {
     @Published public var alert: Alert?
     @Published public var toastConfig: ToastConfiguration?
+    @Published public var confirmationDialog: ConfirmationDialog?
 }

--- a/Sources/Presenting/Models/Presenter.swift
+++ b/Sources/Presenting/Models/Presenter.swift
@@ -6,7 +6,7 @@
 
 import SwiftUI
 
-public typealias PresentableObject = SheetManageable & FullScreenCoverManageable & AlertManageable & ToastManageable
+public typealias PresentableObject = SheetManageable & FullScreenCoverManageable & AlertManageable & ToastManageable & ConfirmationDialogManageable
 
 public final class Presenter<Routes: Presentable>: PresentableObject {
     public typealias Destination = Routes
@@ -16,4 +16,5 @@ public final class Presenter<Routes: Presentable>: PresentableObject {
     @Published public var fullScreenCover: Destination?
     @Published public var alert: Alert?
     @Published public var toastConfig: ToastConfiguration?
+    @Published public var confirmationDialog: ConfirmationDialog?
 }

--- a/Sources/Presenting/Views/BasicPresentingView.swift
+++ b/Sources/Presenting/Views/BasicPresentingView.swift
@@ -25,6 +25,10 @@ public struct BasicPresentingView<RootView: View>: View {
                 rootView.toast(config: toastConfig,
                                onCompletion: presenter.dismissToast)
             }
+            .iflet(presenter.confirmationDialog) { rootView, confirmationDialog in
+                rootView.confirmationDialog(config: confirmationDialog,
+                                            isPresented: presenter.isConfirmationDialogPresented)
+            }
     }
 }
 

--- a/Sources/Presenting/Views/PresentingView.swift
+++ b/Sources/Presenting/Views/PresentingView.swift
@@ -30,6 +30,10 @@ public struct PresentingView<RootView: View, Routes: Presentable>: View {
                 rootView.toast(config: toastConfig,
                                onCompletion: presenter.dismissToast)
             }
+            .iflet(presenter.confirmationDialog) { rootView, confirmationDialog in
+                rootView.confirmationDialog(config: confirmationDialog,
+                                            isPresented: presenter.isConfirmationDialogPresented)
+            }
 #if !os(macOS)
             .fullScreenCover(item: $presenter.fullScreenCover, onDismiss: {
                 presenter.onDismiss?()

--- a/Sources/Presenting/Views/View+Extensions.swift
+++ b/Sources/Presenting/Views/View+Extensions.swift
@@ -18,4 +18,9 @@ extension View {
             self
         }
     }
+
+    /// Erases the type of a view using AnyView.
+    func eraseToAnyView() -> AnyView {
+        AnyView(self)
+    }
 }

--- a/Tests/PresentingTests/ConfirmationDialogManageableTests.swift
+++ b/Tests/PresentingTests/ConfirmationDialogManageableTests.swift
@@ -1,0 +1,84 @@
+//
+//  ConfirmationDialogManageableTests.swift
+//
+//
+//  Created by Giorgio Latour on 1/15/24.
+//
+
+import SwiftUI
+import XCTest
+@testable import Presenting
+
+final class ConfirmationDialogManageableTests: XCTestCase {
+    private var presenter: MockConfirmationDialogManager!
+
+    override func setUp() {
+        super.setUp()
+        presenter = MockConfirmationDialogManager()
+    }
+
+    override func tearDown() {
+        presenter = nil
+        super.tearDown()
+    }
+
+    func testPresentConfirmationDialog() {
+        let confirmationDialog = ConfirmationDialog(Text("Test1")) {
+            Button("TestButton") { }
+        }
+        presenter.presentConfirmationDialog(confirmationDialog)
+        XCTAssertNotNil(presenter.confirmationDialog)
+    }
+
+    func testPresentConfirmationDialogWithMessage() {
+        let confirmationDialog = ConfirmationDialog(Text("Test2")) {
+            Button("TestButton") { }
+        } message: {
+            Text("TestMessage")
+        }
+        presenter.presentConfirmationDialog(confirmationDialog)
+        XCTAssertNotNil(presenter.confirmationDialog)
+    }
+
+    func testPresentConfirmationDialogWithData() {
+        let mockData: MockData? = MockData()
+        let confirmationDialog = ConfirmationDialog(
+            Text("Test3"), titleVisibility: .automatic, presenting: mockData) { mockData in
+                Button("\(mockData.buttonTitle)") { }
+            } message: { mockData in
+                Text("\(mockData.message)")
+            }
+        presenter.presentConfirmationDialog(confirmationDialog)
+        XCTAssertNotNil(presenter.confirmationDialog)
+    }
+
+    func testPresentConfirmationDialogWithEmptyData() {
+        let mockData: MockData? = nil
+        let confirmationDialog = ConfirmationDialog(
+            Text("Test3"), titleVisibility: .automatic, presenting: mockData) { mockData in
+                Button("\(mockData.buttonTitle)") { }
+            } message: { mockData in
+                Text("\(mockData.message)")
+            }
+        presenter.presentConfirmationDialog(confirmationDialog)
+        XCTAssertNotNil(presenter.confirmationDialog)
+    }
+
+    func testDismissToast() {
+        let confirmationDialog = ConfirmationDialog(Text("Test1")) {
+            Button("TestButton") { }
+        }
+        presenter.presentConfirmationDialog(confirmationDialog)
+        presenter.dismissConfirmationDialog()
+        XCTAssertNil(presenter.confirmationDialog)
+    }
+}
+
+fileprivate class MockConfirmationDialogManager: ConfirmationDialogManageable {
+    @Published var confirmationDialog: ConfirmationDialog?
+}
+
+fileprivate struct MockData {
+    let buttonTitle = "Button1"
+    let message = "Message"
+}


### PR DESCRIPTION
These changes add support for presenting confirmation dialogs using both the ```Presenter``` and ```BasicPresenter``` presenting views.

# What It Does
* Closes #1 
* Adds a ConfirmationDialog object to hold confirmation dialog related content.
* Adds a ConfirmationDialogManageable protocol.
* Adds a ConfirmationDialog view modifier to create a confirmation dialog using the ConfirmationDialog object.
* Supports all confirmationDialogs that use ```Text("")``` for the title property.
* Emulates the same behavior as confirmationDialog with data (shows an empty confirmation dialog, which produces a warning, if the data is ```nil```) (see notes).
* Extends View with an ```eraseToAnyView()``` helper function (see notes).
* Adds documentation to the README.
* Adds unit tests for ConfirmationDialogManageable.

# How I Tested
* I set up a demo project and tested all the confirmation dialog initializers with both PresentingView and BasicPresentingView on iOS 17.2 and 16.4.
* Wrote another Unit Test class for the new protocol and verified everything passes.

# Notes
* Confirmation dialogs can use data of an optional generic type to produce the dialog's content. When the data is ```nil```, the ```actions``` and ```message``` fields are initialized with ```EmptyView()```. This causes a warning to be shown upon presentation of the dialog. I verified that this is the same behavior as when using the native confirmation dialog with ```nil``` data.
* The ```actions``` and ```message``` properties have the ```AnyView``` type because we don't know the concrete type of the view that the user will pass into the confirmation dialog initializer. Generics don't work here because we would eventually be required to specify a type when creating ```PresentingView``` or ```BasicPresentingView```. At that point we still don't know the type of the confirmation dialog's contents, so ```AnyView``` becomes our only option.
 
# Screenshot
<img width="320" alt="Confirmation Dialogs in Action" src="https://github.com/JamesSedlacek/Presenting/assets/111900227/1166a655-602e-4be1-b98d-181b712aca22">

<img width="800" alt="Confirmation Dialogs with nil Data" src="https://github.com/JamesSedlacek/Presenting/assets/111900227/8d7e7712-5035-444c-9deb-5f7f2d4e8705">